### PR TITLE
"Disable" http4xx by default

### DIFF
--- a/extensions/http4xx.js
+++ b/extensions/http4xx.js
@@ -1,5 +1,5 @@
 module.exports = function() {
-  return [
+  return [/*
     {
       priority: 'early',
       matchErr: 499,
@@ -7,5 +7,5 @@ module.exports = function() {
         res.body = `Error ${res.errCode}`;
       }
     }
-  ]
+  ]*/
 }


### PR DESCRIPTION
If fs.readdir lists it before randomfile.js, the latter won't work. This will be fixed along with some changes to extensions in a later PR.